### PR TITLE
Add download_attachment functionality to extract email attachments

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -112,6 +112,31 @@ async def toggle_label(msg_id: str, label_name: str, action: str = "add", client
     return await client.toggle_label_email(msg_id, label_name, action)
 
 
+@app.get("/download_attachment")
+@assign_doc()
+async def download_attachment(
+        msg_id: str,
+        attachment_index: int = 0,
+        save_dir: Optional[str] = None,
+        client=Depends(get_client)
+):
+    """
+    Downloads an attachment from a specific email message.
+
+    Args:
+        msg_id: The ID of the message containing the attachment.
+        attachment_index: The index of the attachment to download (0-based). Defaults to 0 (first attachment).
+        save_dir: Optional directory path to save the attachment. If None, returns base64 data.
+
+    Returns:
+        dict: A dict containing:
+            - operation_status: 'succeeded' or 'failed'.
+            - operation_message: Description of the download result.
+            - result: Dict containing filename, filepath (if saved), mimeType, size, and optionally base64 data.
+    """
+    return await client.download_attachment(msg_id, attachment_index, save_dir)
+
+
 @app.get("/load_email_settings")
 async def load_email_settings() -> EmailSettings:
     """

--- a/email_client/BaseEmailProvider.py
+++ b/email_client/BaseEmailProvider.py
@@ -38,6 +38,7 @@ class EmailClient(ABC):
     REPLY_TO_EMAIL_SUCCESS_MESSAGE = "Replied to email successfully"
     DELETE_EMAIL_SUCCESS_MESSAGE = "Email has been deleted successfully"
     ARCHIVE_EMAIL_SUCCESS_MESSAGE = "Emails have been archived successfully"
+    DOWNLOAD_ATTACHMENT_SUCCESS_MESSAGE = "Attachment has been downloaded successfully"
 
     @assign_doc()
     @abstractmethod
@@ -93,6 +94,25 @@ class EmailClient(ABC):
     @assign_doc()
     @abstractmethod
     async def toggle_label_email(self, msg_id: str, label_name: str, action: str = "add") -> Dict[str, Any]:
+        pass
+
+    @assign_doc()
+    @abstractmethod
+    async def download_attachment(self, msg_id: str, attachment_index: int = 0, save_dir: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Downloads an attachment from a specific email message.
+
+        Args:
+            msg_id: The ID of the message containing the attachment.
+            attachment_index: The index of the attachment to download (0-based). Defaults to 0 (first attachment).
+            save_dir: Optional directory path to save the attachment. If None, returns base64 data.
+
+        Returns:
+            dict: A dict containing:
+                - operation_status: 'succeeded' or 'failed'.
+                - operation_message: Description of the download result.
+                - result: Dict containing filename, filepath (if saved), or base64 data.
+        """
         pass
 
     @staticmethod

--- a/email_client/gmail_helpers.py
+++ b/email_client/gmail_helpers.py
@@ -320,6 +320,103 @@ class GmailClient(EmailClient):
             result = {self.OP_RESULT: EmailingStatus.FAILED, self.OP_MESSAGE: str(e)}
             return result
 
+    async def download_attachment(self, msg_id: str, attachment_index: int = 0, save_dir: str = None):
+        """
+        Downloads an attachment from a specific email message.
+
+        Args:
+            msg_id: The ID of the message containing the attachment.
+            attachment_index: The index of the attachment to download (0-based). Defaults to 0 (first attachment).
+            save_dir: Optional directory path to save the attachment. If None, returns base64 data.
+
+        Returns:
+            dict: A dict containing operation status, message, and result with attachment data.
+        """
+        try:
+            # Fetch the message
+            msg_data = await asyncio.to_thread(
+                self.service.users().messages().get(userId='me', id=msg_id, format='full').execute
+            )
+            payload = msg_data.get('payload', {})
+
+            # Find all attachments with their attachment IDs
+            attachments = []
+            if 'parts' in payload:
+                for part in payload['parts']:
+                    filename = part.get('filename')
+                    body = part.get('body', {})
+                    attachment_id = body.get('attachmentId')
+                    if filename and attachment_id:
+                        attachments.append({
+                            'filename': filename,
+                            'attachmentId': attachment_id,
+                            'mimeType': part.get('mimeType'),
+                            'size': body.get('size', 0)
+                        })
+
+            if not attachments:
+                result = {
+                    self.OP_RESULT: EmailingStatus.FAILED,
+                    self.OP_MESSAGE: f"No attachments found in message {msg_id}"
+                }
+                return result
+
+            if attachment_index >= len(attachments):
+                result = {
+                    self.OP_RESULT: EmailingStatus.FAILED,
+                    self.OP_MESSAGE: f"Attachment index {attachment_index} out of range. Message has {len(attachments)} attachment(s)."
+                }
+                return result
+
+            attachment_info = attachments[attachment_index]
+            attachment_id = attachment_info['attachmentId']
+            filename = attachment_info['filename']
+
+            # Fetch the actual attachment data
+            attachment_data = await asyncio.to_thread(
+                self.service.users().messages().attachments().get(
+                    userId='me',
+                    messageId=msg_id,
+                    id=attachment_id
+                ).execute
+            )
+
+            file_data_b64 = attachment_data.get('data', '')
+
+            result_data = {
+                'filename': filename,
+                'mimeType': attachment_info['mimeType'],
+                'size': attachment_info['size'],
+                'total_attachments': len(attachments)
+            }
+
+            if save_dir:
+                # Decode and save to file
+                os.makedirs(save_dir, exist_ok=True)
+                file_data = base64.urlsafe_b64decode(file_data_b64)
+                filepath = os.path.join(save_dir, filename)
+
+                with open(filepath, 'wb') as f:
+                    f.write(file_data)
+
+                result_data['filepath'] = filepath
+                result_data['saved'] = True
+            else:
+                # Return base64 data
+                result_data['data'] = file_data_b64
+                result_data['saved'] = False
+
+            result = {
+                self.OP_RESULT: EmailingStatus.SUCCEEDED,
+                self.OP_MESSAGE: self.DOWNLOAD_ATTACHMENT_SUCCESS_MESSAGE,
+                "result": result_data
+            }
+            return result
+
+        except Exception as e:
+            result = {self.OP_RESULT: EmailingStatus.FAILED, self.OP_MESSAGE: str(e)}
+            return result
+
 
 async def test():
     credential_file = "../credentials.json"

--- a/email_client/outlook_helpers.py
+++ b/email_client/outlook_helpers.py
@@ -399,6 +399,82 @@ class OutlookClient(EmailClient):
                 self.OP_MESSAGE: f"Failed to update label: {e}"
             }
 
+    async def download_attachment(self, msg_id: str, attachment_index: int = 0, save_dir: str = None) -> Dict[str, Any]:
+        """
+        Downloads an attachment from a specific email message using Microsoft Graph API.
+
+        Args:
+            msg_id: The ID of the message containing the attachment.
+            attachment_index: The index of the attachment to download (0-based). Defaults to 0 (first attachment).
+            save_dir: Optional directory path to save the attachment. If None, returns base64 data.
+
+        Returns:
+            dict: A dict containing operation status, message, and result with attachment data.
+        """
+        import base64
+
+        try:
+            # List all attachments
+            attachments_resp = await self._request("GET", f"/me/messages/{msg_id}/attachments")
+            attachments = attachments_resp.get("value", [])
+
+            if not attachments:
+                return {
+                    self.OP_RESULT: EmailingStatus.FAILED,
+                    self.OP_MESSAGE: f"No attachments found in message {msg_id}"
+                }
+
+            if attachment_index >= len(attachments):
+                return {
+                    self.OP_RESULT: EmailingStatus.FAILED,
+                    self.OP_MESSAGE: f"Attachment index {attachment_index} out of range. Message has {len(attachments)} attachment(s)."
+                }
+
+            attachment = attachments[attachment_index]
+            attachment_id = attachment.get("id")
+            filename = attachment.get("name", "attachment")
+            content_type = attachment.get("contentType", "application/octet-stream")
+            size = attachment.get("size", 0)
+
+            # Get the attachment content
+            attachment_data = await self._request("GET", f"/me/messages/{msg_id}/attachments/{attachment_id}")
+            content_bytes_b64 = attachment_data.get("contentBytes", "")
+
+            result_data = {
+                'filename': filename,
+                'mimeType': content_type,
+                'size': size,
+                'total_attachments': len(attachments)
+            }
+
+            if save_dir:
+                # Decode and save to file
+                os.makedirs(save_dir, exist_ok=True)
+                file_data = base64.b64decode(content_bytes_b64)
+                filepath = os.path.join(save_dir, filename)
+
+                with open(filepath, 'wb') as f:
+                    f.write(file_data)
+
+                result_data['filepath'] = filepath
+                result_data['saved'] = True
+            else:
+                # Return base64 data
+                result_data['data'] = content_bytes_b64
+                result_data['saved'] = False
+
+            return {
+                self.OP_RESULT: EmailingStatus.SUCCEEDED,
+                self.OP_MESSAGE: self.DOWNLOAD_ATTACHMENT_SUCCESS_MESSAGE,
+                "result": result_data
+            }
+
+        except Exception as e:
+            return {
+                self.OP_RESULT: EmailingStatus.FAILED,
+                self.OP_MESSAGE: str(e)
+            }
+
 
 async def test():
     load_dotenv()


### PR DESCRIPTION
## Summary

- Adds `download_attachment` method to the base `EmailClient` class and implements it for both Gmail and Outlook providers
- Adds new `/download_attachment` API endpoint
- Allows downloading attachments by message ID and attachment index
- Supports both saving to disk and returning base64-encoded data

## New Endpoint

```
GET /download_attachment?msg_id=<id>&attachment_index=0&save_dir=/path/to/save
```

**Parameters:**
- `msg_id` (required) - The email message ID
- `attachment_index` (default: 0) - Which attachment to download (0-based)
- `save_dir` (optional) - If provided, saves file to disk; otherwise returns base64 data

**Response:**
```json
{
  "operation_status": "succeeded",
  "operation_message": "Attachment has been downloaded successfully",
  "result": {
    "filename": "document.pdf",
    "mimeType": "application/pdf",
    "size": 249216,
    "total_attachments": 2,
    "saved": true,
    "filepath": "/path/to/save/document.pdf"
  }
}
```

## Test Results

| Test | Result |
|------|--------|
| Download as base64 | ✅ Works |
| Save to disk | ✅ Works |
| Multi-attachment email (index selection) | ✅ Works |
| Invalid index error handling | ✅ Works |
| No attachments error handling | ✅ Works |

## Files Changed

- `email_client/BaseEmailProvider.py` - Added abstract method + success message
- `email_client/gmail_helpers.py` - Gmail implementation
- `email_client/outlook_helpers.py` - Outlook/Graph API implementation  
- `api/main.py` - New endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)